### PR TITLE
Decoupled extension points for electron variants

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -406,7 +406,7 @@ action("electron_generate_node_defines") {
   args = [ rebase_path(target_gen_dir) ] + rebase_path(inputs)
 }
 
-spin_defines = exec_script("build/spin.py")
+spin_defines = exec_script("build/spin.py", [], "list lines")
 
 source_set("electron_lib") {
   configs += [
@@ -561,7 +561,7 @@ source_set("electron_lib") {
     ]
   }
   if (spin_defines != []) {
-    deps += ["//electron-spin"]
+    deps += [ "//electron-spin:electron_hooks" ]
   }
   if (is_mac) {
     deps += [

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -406,7 +406,7 @@ action("electron_generate_node_defines") {
   args = [ rebase_path(target_gen_dir) ] + rebase_path(inputs)
 }
 
-spin_defines = exec_script("build/spin.py")
+spin_defines = exec_script("build/spin.py", [], "list lines")
 
 source_set("electron_lib") {
   configs += [

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -406,6 +406,8 @@ action("electron_generate_node_defines") {
   args = [ rebase_path(target_gen_dir) ] + rebase_path(inputs)
 }
 
+spin_defines = exec_script("build/spin.py")
+
 source_set("electron_lib") {
   configs += [
     "//v8:external_startup_data",
@@ -515,7 +517,7 @@ source_set("electron_lib") {
     "//third_party/blink/renderer",
   ]
 
-  defines = [ "V8_DEPRECATION_WARNINGS" ]
+  defines = [ "V8_DEPRECATION_WARNINGS" ] + spin_defines
   libs = []
 
   if (is_linux) {
@@ -558,7 +560,9 @@ source_set("electron_lib") {
       "shell/browser/fake_location_provider.h",
     ]
   }
-
+  if (spin_defines != []) {
+    deps += ["//electron-spin"]
+  }
   if (is_mac) {
     deps += [
       "//components/remote_cocoa/app_shim",

--- a/build/args/testing.gn
+++ b/build/args/testing.gn
@@ -4,7 +4,7 @@ is_component_build = false
 is_component_ffmpeg = true
 is_official_build = false
 dcheck_always_on = true
-symbol_level = 1
+symbol_level = 2
 
 # This may be guarded behind is_chrome_branded alongside
 # proprietary_codecs https://webrtc-review.googlesource.com/c/src/+/36321,

--- a/build/spin.py
+++ b/build/spin.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+from os      import chdir
+from os.path import dirname, isdir, isfile, join
+
+spin_dir = join(dirname(__file__), '..', '..', 'electron-spin')
+
+if isdir(spin_dir):
+  chdir(spin_dir)
+else:
+  exit(0)
+
+if not isfile('BUILD.gn'):
+  print('error: electron-spin directory present, but electron-spin/BUILD.gn absent. It is expected to define the target electron-spin')
+  exit(1)
+
+if isfile('builtin_schemes.h'):
+  print('ADDITIONAL_BUILTIN_SCHEMES')

--- a/build/spin.py
+++ b/build/spin.py
@@ -2,6 +2,7 @@
 
 from os      import chdir
 from os.path import dirname, isdir, isfile, join
+from sys     import stderr
 
 spin_dir = join(dirname(__file__), '..', '..', 'electron-spin')
 
@@ -11,7 +12,7 @@ else:
   exit(0)
 
 if not isfile('BUILD.gn'):
-  print('error: electron-spin directory present, but electron-spin/BUILD.gn absent. It is expected to define the target electron-spin')
+  print('error: electron-spin directory present, but electron-spin/BUILD.gn absent. It is expected to define the target electron-spin', file=stderr)
   exit(1)
 
 if isfile('builtin_schemes.h'):

--- a/build/spin.py
+++ b/build/spin.py
@@ -2,6 +2,7 @@
 
 from os      import chdir
 from os.path import dirname, isdir, isfile, join
+from sys     import stderr
 
 spin_dir = join(dirname(__file__), '..', '..', 'electron-spin')
 
@@ -11,8 +12,14 @@ else:
   exit(0)
 
 if not isfile('BUILD.gn'):
-  print('error: electron-spin directory present, but electron-spin/BUILD.gn absent. It is expected to define the target electron-spin')
+  print('error: electron-spin directory present, but electron-spin/BUILD.gn absent. It is expected to define the target electron-spin', file=stderr)
   exit(1)
 
-if isfile('builtin_schemes.h'):
-  print('ADDITIONAL_BUILTIN_SCHEMES')
+for header in ['additional_schemes',
+               'interceptors',
+               'preferences',
+               'pre_main_message_loop_run',
+               'scheme_url_loader',
+               ]:
+  if isfile(header + '.h'):
+    print('ELECTRON_SPIN_' + header.upper())

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -25,6 +25,10 @@
 #include "shell/common/process_util.h"
 #include "url/url_util.h"
 
+#ifdef ELECTRON_SPIN_ADDITIONAL_SCHEMES
+#include "electron-spin/additional_schemes.h"
+#endif
+
 namespace {
 
 // List of registered custom standard schemes.
@@ -272,7 +276,11 @@ v8::Local<v8::Promise> Protocol::IsProtocolHandled(const std::string& scheme,
           // So we have to test against a hard-coded builtin schemes
           // list make it work with old code. We should deprecate
           // this API with the new |isProtocolRegistered| API.
-          base::Contains(kBuiltinSchemes, scheme));
+          base::Contains(kBuiltinSchemes, scheme)
+#ifdef ELECTRON_SPIN_ADDITIONAL_SCHEMES
+          || base::Contains(electron_spin::AdditionalSchemes(), scheme)
+#endif
+  );
 }
 
 void Protocol::HandleOptionalCallback(gin::Arguments* args,

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -79,6 +79,10 @@
 #include "shell/common/extensions/electron_extensions_client.h"
 #endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 
+#if ELECTRON_SPIN_PREFERENCES
+#include "electron-spin/preferences.h"
+#endif
+
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS) || \
     BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
 #include "components/pref_registry/pref_registry_syncable.h"
@@ -356,6 +360,10 @@ void ElectronBrowserContext::InitPrefs() {
   if (!in_memory_)
     extensions::ExtensionPrefs::RegisterProfilePrefs(registry.get());
   extensions::PermissionsManager::RegisterProfilePrefs(registry.get());
+#endif
+
+#ifdef ELECTRON_SPIN_PREFERENCES
+  electron_spin::RegisterPreferences(registry.get());
 #endif
 
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -116,6 +116,10 @@
 #include "shell/common/extensions/electron_extensions_client.h"
 #endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 
+#ifdef ELECTRON_SPIN_PRE_MAIN_MESSAGE_LOOP_RUN
+#include "electron-spin/pre_main_message_loop_run.h"
+#endif
+
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
 #include "chrome/browser/spellchecker/spellcheck_factory.h"  // nogncheck
 #endif
@@ -482,6 +486,13 @@ int ElectronBrowserMainParts::PreMainMessageLoopRun() {
   Browser::Get()->PreMainMessageLoopRun();
 
   fake_browser_process_->PreMainMessageLoopRun();
+
+#ifdef ELECTRON_SPIN_PRE_MAIN_MESSAGE_LOOP_RUN
+  for (auto& iter : ElectronBrowserContext::browser_context_map()) {
+    auto c = iter.second.get();
+    electron_spin::PreMainMessageLoopRun(c, c->prefs());
+  }
+#endif
 
   return GetExitCode();
 }


### PR DESCRIPTION
Provide extension points so one can create downstream, modified versions of electron that don't require maintaining elaborate patch sets.
